### PR TITLE
Skip adding comment if elem.mode is unsupported

### DIFF
--- a/danmakuC/bilibili.py
+++ b/danmakuC/bilibili.py
@@ -29,23 +29,21 @@ def proto2ass(
         proto_file = proto_file.read()
     target = BiliCommentProto()
     target.ParseFromString(proto_file)
+    # elem.mode > 8, example: https://www.bilibili.com/video/BV1Js411f78P/
+    mode_map = {1: 0, 4: 2, 5: 1, 6: 3, 7: 4}
     for elem in target.elems:
+        if elem.mode not in mode_map:
+            continue
         try:
-            assert elem.mode in (1,4,5,6,7,8)
-            if elem.mode in (1,4,5,6,7):
-                ass.add_comment(
+            ass.add_comment(
                 elem.progress / 1000,  # 视频内出现的时间
                 elem.ctime,  # 弹幕的发送时间（时间戳）
                 elem.content,
                 elem.fontsize,
-                {1: 0, 4: 2, 5: 1, 6: 3, 7: 4}[elem.mode],
+                mode_map[elem.mode],
                 elem.color,
             )
-            elif elem.mode == 8:
-                # scripted comment
-                continue
-        except (AssertionError, TypeError):
-            # AssertionError: elem.mode > 8, example: https://www.bilibili.com/video/BV1Js411f78P/
+        except TypeError:
             # TypeError: incase integer overflow https://github.com/HFrost0/bilix/issues/102
             continue
     if out_filename:

--- a/danmakuC/bilibili.py
+++ b/danmakuC/bilibili.py
@@ -30,10 +30,10 @@ def proto2ass(
     target = BiliCommentProto()
     target.ParseFromString(proto_file)
     for elem in target.elems:
-        if elem.mode == 8:
-            continue  # ignore scripted comment
         try:
-            ass.add_comment(
+            assert elem.mode in (1,4,5,6,7,8)
+            if elem.mode in (1,4,5,6,7):
+                ass.add_comment(
                 elem.progress / 1000,  # 视频内出现的时间
                 elem.ctime,  # 弹幕的发送时间（时间戳）
                 elem.content,
@@ -41,7 +41,12 @@ def proto2ass(
                 {1: 0, 4: 2, 5: 1, 6: 3, 7: 4}[elem.mode],
                 elem.color,
             )
-        except TypeError:  # incase integer overflow https://github.com/HFrost0/bilix/issues/102
+            elif elem.mode == 8:
+                # scripted comment
+                continue
+        except (AssertionError, TypeError):
+            # AssertionError: elem.mode > 8, example: https://www.bilibili.com/video/BV1Js411f78P/
+            # TypeError: incase integer overflow https://github.com/HFrost0/bilix/issues/102
             continue
     if out_filename:
         return ass.write_to_file(out_filename)


### PR DESCRIPTION
## 问题

<https://www.bilibili.com/video/BV1Js411f78P/> 这个视频含有两个 `elem.mode == 10` 的弹幕：

```danmaku
id: 272777941
progress: 14161
mode: 10
fontsize: 25
color: 16777215
midHash: "9a65fce8"
content: ">>>>>>>>"
ctime: 1375347954
weight: 11
idStr: "272777941"

id: 273146948
progress: 7625
mode: 10
fontsize: 25
color: 16777215
midHash: "c7b09d08"
content: "420"
ctime: 1375391159
weight: 11
idStr: "273146948"
```

导致在 `proto2ass()` 的

https://github.com/HFrost0/danmakuC/blob/bb25b657a9a8df1e0d0df071bd3a79ee8b3782e7/danmakuC/bilibili.py#L41

处发生了 `KeyError: 10` 。

---

## 修复

本 PR 参考了隔壁 biliass 的做法，先 assert elem.mode 再 catch 跳过无效的弹幕。

https://github.com/yutto-dev/biliass/blob/a095fac4614437c64ce0b690bf6e390c59848cd9/biliass/biliass.py#L137

